### PR TITLE
feat: add base data model implementation for journal model

### DIFF
--- a/journal-service/pom.xml
+++ b/journal-service/pom.xml
@@ -58,11 +58,13 @@
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo</artifactId>
             <version>4.18.0</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>de.flapdoodle.embed</groupId>
             <artifactId>de.flapdoodle.embed.mongo.spring30x</artifactId>
             <version>4.3.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/journal-service/pom.xml
+++ b/journal-service/pom.xml
@@ -54,6 +54,16 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <version>4.18.0</version>
+        </dependency>
+        <dependency>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo.spring30x</artifactId>
+            <version>4.3.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/journal-service/pom.xml
+++ b/journal-service/pom.xml
@@ -39,11 +39,15 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.1.Final</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/journal-service/src/main/java/com/kioke/journal/KiokeJournalServiceApplication.java
+++ b/journal-service/src/main/java/com/kioke/journal/KiokeJournalServiceApplication.java
@@ -2,8 +2,10 @@ package com.kioke.journal;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
 
 @SpringBootApplication
+@EnableMongoAuditing
 public class KiokeJournalServiceApplication {
 
   public static void main(String[] args) {

--- a/journal-service/src/main/java/com/kioke/journal/model/Journal.java
+++ b/journal-service/src/main/java/com/kioke/journal/model/Journal.java
@@ -1,0 +1,28 @@
+package com.kioke.journal.model;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "journal")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Journal {
+  @Id private String id;
+
+  private String title;
+
+  private String template;
+
+  private List<Page> pages;
+
+  @CreatedDate private LocalDateTime createdAt;
+  @LastModifiedDate private LocalDateTime lastUpdated;
+}

--- a/journal-service/src/main/java/com/kioke/journal/model/Journal.java
+++ b/journal-service/src/main/java/com/kioke/journal/model/Journal.java
@@ -4,6 +4,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,6 +16,7 @@ import org.springframework.data.mongodb.core.mapping.Document;
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Journal {
   @Id private String id;
 

--- a/journal-service/src/main/java/com/kioke/journal/model/Journal.java
+++ b/journal-service/src/main/java/com/kioke/journal/model/Journal.java
@@ -1,7 +1,8 @@
 package com.kioke.journal.model;
 
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
-import java.util.*;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -17,12 +18,13 @@ import org.springframework.data.mongodb.core.mapping.Document;
 public class Journal {
   @Id private String id;
 
-  private String title;
+  @NotNull private String title;
 
-  private String template;
+  @NotNull private String template;
 
   private List<Page> pages;
 
   @CreatedDate private LocalDateTime createdAt;
+
   @LastModifiedDate private LocalDateTime lastUpdated;
 }

--- a/journal-service/src/main/java/com/kioke/journal/model/Page.java
+++ b/journal-service/src/main/java/com/kioke/journal/model/Page.java
@@ -1,0 +1,15 @@
+package com.kioke.journal.model;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "page")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Page {
+  @Id private String id;
+}

--- a/journal-service/src/main/java/com/kioke/journal/repository/JournalRepository.java
+++ b/journal-service/src/main/java/com/kioke/journal/repository/JournalRepository.java
@@ -1,0 +1,6 @@
+package com.kioke.journal.repository;
+
+import com.kioke.journal.model.Journal;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface JournalRepository extends MongoRepository<Journal, String> {}

--- a/journal-service/src/test/java/com/kioke/journal/repository/JournalRepositoryTest.java
+++ b/journal-service/src/test/java/com/kioke/journal/repository/JournalRepositoryTest.java
@@ -1,0 +1,44 @@
+package com.kioke.journal.repository;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import com.kioke.journal.model.Journal;
+import com.kioke.journal.model.Page;
+import java.util.ArrayList;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public class JournalRepositoryTest {
+  @Autowired JournalRepository journalRepository;
+
+  private static Journal buildSampleJournal() {
+    return Journal.builder()
+        .title(UUID.randomUUID().toString())
+        .template(UUID.randomUUID().toString())
+        .pages(new ArrayList<Page>())
+        .build();
+  }
+
+  @Test
+  public void test_saveJournal_savesSuccessfullyWithCorrectFields() {
+    Journal journalToSave = buildSampleJournal();
+    Journal savedJournal = journalRepository.save(journalToSave);
+
+    assertNotNull(savedJournal);
+    assertEquals(journalToSave.getTitle(), savedJournal.getTitle());
+    assertEquals(journalToSave.getTemplate(), savedJournal.getTemplate());
+  }
+
+  @Test
+  public void test_saveJournal_savesSuccessfullyWithNonNullId() {
+    Journal journalToSave = buildSampleJournal();
+    Journal savedJournal = journalRepository.save(journalToSave);
+
+    assertNotNull(savedJournal);
+    assertNotNull(savedJournal.getId());
+  }
+}

--- a/journal-service/src/test/java/com/kioke/journal/repository/JournalRepositoryTest.java
+++ b/journal-service/src/test/java/com/kioke/journal/repository/JournalRepositoryTest.java
@@ -41,4 +41,22 @@ public class JournalRepositoryTest {
     assertNotNull(savedJournal);
     assertNotNull(savedJournal.getId());
   }
+
+  @Test
+  public void test_saveJournal_savesSuccessfullyWithNonNullCreatedAt() {
+    Journal journalToSave = buildSampleJournal();
+    Journal savedJournal = journalRepository.save(journalToSave);
+
+    assertNotNull(savedJournal);
+    assertNotNull(savedJournal.getCreatedAt());
+  }
+
+  @Test
+  public void test_saveJournal_savesSuccessfullyWithNonNullLastUpdated() {
+    Journal journalToSave = buildSampleJournal();
+    Journal savedJournal = journalRepository.save(journalToSave);
+
+    assertNotNull(savedJournal);
+    assertNotNull(savedJournal.getLastUpdated());
+  }
 }

--- a/journal-service/src/test/resources/application.yml
+++ b/journal-service/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  data:
+    mongodb:
+      host: localhost
+      port: 27017
+      database: test
+
+de:
+  flapdoodle:
+    mongodb:
+      embedded:
+        version: 5.0.2

--- a/journal-service/src/test/resources/application.yml
+++ b/journal-service/src/test/resources/application.yml
@@ -1,10 +1,3 @@
-spring:
-  data:
-    mongodb:
-      host: localhost
-      port: 27017
-      database: test
-
 de:
   flapdoodle:
     mongodb:


### PR DESCRIPTION
## Description
- Add the base data model implementation for the journal model in the journal service.
- Test code is also added for the repository layer using an in-memory embedded MongoDB service.

## Pull Request Type
- [x] Add a new feature.
- [ ] Fix an existing bug.
- [ ] Refactor code.
- [ ] CI related changes.
- [ ] Documentation related changes.
- [ ] Other

## Related Issues
- Closes #10