### PR TITLE
feat: add logic for creating journal permissions in auth service

### DIFF
--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
             <version>4.1.3</version>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>8.0.1.Final</version>
+        </dependency>
 
         <dependency>
             <groupId>org.postgresql</groupId>

--- a/auth-service/src/main/java/com/kioke/auth/controller/AclController.java
+++ b/auth-service/src/main/java/com/kioke/auth/controller/AclController.java
@@ -1,0 +1,36 @@
+package com.kioke.auth.controller;
+
+import com.kioke.auth.dto.CreateJournalRequestBodyDto;
+import com.kioke.auth.model.Journal;
+import com.kioke.auth.model.User;
+import com.kioke.auth.service.AclService;
+import com.kioke.auth.service.JournalService;
+import com.kioke.auth.service.UserService;
+import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Slf4j
+@RequestMapping("")
+public class AclController {
+  @Autowired @Lazy AclService aclService;
+  @Autowired @Lazy JournalService journalService;
+  @Autowired @Lazy UserService userService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public void createJournal(@Valid @RequestBody CreateJournalRequestBodyDto requestBody)
+      throws Exception {
+    User user = userService.getUserById(requestBody.getUid());
+    Journal journal = journalService.getJournalById(requestBody.getJid());
+    aclService.createAclEntryForJournal(user, journal);
+  }
+}

--- a/auth-service/src/main/java/com/kioke/auth/controller/AclController.java
+++ b/auth-service/src/main/java/com/kioke/auth/controller/AclController.java
@@ -13,13 +13,11 @@ import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @Slf4j
-@RequestMapping("")
 public class AclController {
   @Autowired @Lazy AclService aclService;
   @Autowired @Lazy JournalService journalService;
@@ -29,8 +27,8 @@ public class AclController {
   @ResponseStatus(HttpStatus.CREATED)
   public void createJournal(@Valid @RequestBody CreateJournalRequestBodyDto requestBody)
       throws Exception {
-    User user = userService.getUserById(requestBody.getUid());
-    Journal journal = journalService.getJournalById(requestBody.getJid());
-    aclService.createAclEntryForJournal(user, journal);
+    User user = userService.getOrCreateUser(requestBody.getUid());
+    Journal journal = journalService.getOrCreateJournal(requestBody.getJid());
+    aclService.createAclEntry(user, journal);
   }
 }

--- a/auth-service/src/main/java/com/kioke/auth/dto/CreateJournalRequestBodyDto.java
+++ b/auth-service/src/main/java/com/kioke/auth/dto/CreateJournalRequestBodyDto.java
@@ -1,0 +1,10 @@
+package com.kioke.auth.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+
+@Data
+public class CreateJournalRequestBodyDto {
+  @NotNull private String uid;
+  @NotNull private String jid;
+}

--- a/auth-service/src/main/java/com/kioke/auth/exception/GlobalExceptionHandler.java
+++ b/auth-service/src/main/java/com/kioke/auth/exception/GlobalExceptionHandler.java
@@ -1,0 +1,23 @@
+package com.kioke.auth.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@Slf4j
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler({Exception.class})
+  public ResponseEntity<String> handleException(Exception e) {
+    HttpStatus status = GlobalExceptionHandler.getStatusFromException(e);
+    log.error(e.toString());
+    return ResponseEntity.status(status).body(e.toString());
+  }
+
+  private static HttpStatus getStatusFromException(Exception e) {
+    return HttpStatus.INTERNAL_SERVER_ERROR;
+  }
+}

--- a/auth-service/src/main/java/com/kioke/auth/model/AclEntry.java
+++ b/auth-service/src/main/java/com/kioke/auth/model/AclEntry.java
@@ -14,22 +14,28 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
-@Table
+@Table(name = "ACL_ENTRY_TABLE")
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class AclEntry {
   @Id
-  @GeneratedValue(strategy = GenerationType.SEQUENCE)
+  @GeneratedValue(strategy = GenerationType.UUID)
   private String id;
 
   @ManyToOne
-  @JoinColumn(name = "user", referencedColumnName = "uid")
+  @JoinColumn(name = "uid")
   private User user;
 
   @ManyToOne
-  @JoinColumn(name = "journal", referencedColumnName = "jid")
+  @JoinColumn(name = "jid")
   private Journal journal;
 
   @ElementCollection(fetch = FetchType.EAGER)

--- a/auth-service/src/main/java/com/kioke/auth/model/Journal.java
+++ b/auth-service/src/main/java/com/kioke/auth/model/Journal.java
@@ -4,11 +4,17 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
-@Table
+@Table(name = "JOURNAL_TABLE")
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class Journal {
   @Id
   @Column(name = "jid")

--- a/auth-service/src/main/java/com/kioke/auth/model/User.java
+++ b/auth-service/src/main/java/com/kioke/auth/model/User.java
@@ -4,11 +4,17 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Entity
-@Table
+@Table(name = "USER_TABLE")
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class User {
   @Id
   @Column(name = "uid")

--- a/auth-service/src/main/java/com/kioke/auth/repository/AclRepository.java
+++ b/auth-service/src/main/java/com/kioke/auth/repository/AclRepository.java
@@ -1,6 +1,11 @@
 package com.kioke.auth.repository;
 
 import com.kioke.auth.model.AclEntry;
+import com.kioke.auth.model.Journal;
+import com.kioke.auth.model.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface AclRepository extends JpaRepository<AclEntry, String> {}
+public interface AclRepository extends JpaRepository<AclEntry, String> {
+  public Optional<AclEntry> findByUserAndJournal(User user, Journal journal);
+}

--- a/auth-service/src/main/java/com/kioke/auth/repository/JournalRepository.java
+++ b/auth-service/src/main/java/com/kioke/auth/repository/JournalRepository.java
@@ -1,0 +1,6 @@
+package com.kioke.auth.repository;
+
+import com.kioke.auth.model.Journal;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JournalRepository extends JpaRepository<Journal, String> {}

--- a/auth-service/src/main/java/com/kioke/auth/repository/UserRepository.java
+++ b/auth-service/src/main/java/com/kioke/auth/repository/UserRepository.java
@@ -1,0 +1,6 @@
+package com.kioke.auth.repository;
+
+import com.kioke.auth.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, String> {}

--- a/auth-service/src/main/java/com/kioke/auth/service/AclService.java
+++ b/auth-service/src/main/java/com/kioke/auth/service/AclService.java
@@ -1,0 +1,38 @@
+package com.kioke.auth.service;
+
+import com.kioke.auth.constant.Permission;
+import com.kioke.auth.model.AclEntry;
+import com.kioke.auth.model.Journal;
+import com.kioke.auth.model.User;
+import com.kioke.auth.repository.AclRepository;
+import java.util.Arrays;
+import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AclService {
+  @Autowired @Lazy AclRepository aclRepository;
+
+  public void createAclEntryForJournal(User user, Journal journal) {
+    Optional<AclEntry> optionalAclEntry = aclRepository.findByUserAndJournal(user, journal);
+
+    Permission[] permissions = {Permission.READ, Permission.WRITE};
+
+    AclEntry aclEntry;
+    if (optionalAclEntry.isPresent()) {
+      aclEntry = optionalAclEntry.get();
+      aclEntry.setPermissions(Arrays.asList(permissions));
+    } else {
+      aclEntry =
+          AclEntry.builder()
+              .journal(journal)
+              .user(user)
+              .permissions(Arrays.asList(permissions))
+              .build();
+    }
+
+    aclRepository.save(aclEntry);
+  }
+}

--- a/auth-service/src/main/java/com/kioke/auth/service/AclService.java
+++ b/auth-service/src/main/java/com/kioke/auth/service/AclService.java
@@ -15,23 +15,19 @@ import org.springframework.stereotype.Service;
 public class AclService {
   @Autowired @Lazy AclRepository aclRepository;
 
-  public void createAclEntryForJournal(User user, Journal journal) {
-    Optional<AclEntry> optionalAclEntry = aclRepository.findByUserAndJournal(user, journal);
+  public void createAclEntry(User user, Journal journal) {
+    AclEntry aclEntry =
+        aclRepository
+            .findByUserAndJournal(user, journal)
+            .or(
+                () -> {
+                  AclEntry newAclEntry = AclEntry.builder().journal(journal).user(user).build();
+                  return Optional.of(newAclEntry);
+                })
+            .get();
 
     Permission[] permissions = {Permission.READ, Permission.WRITE};
-
-    AclEntry aclEntry;
-    if (optionalAclEntry.isPresent()) {
-      aclEntry = optionalAclEntry.get();
-      aclEntry.setPermissions(Arrays.asList(permissions));
-    } else {
-      aclEntry =
-          AclEntry.builder()
-              .journal(journal)
-              .user(user)
-              .permissions(Arrays.asList(permissions))
-              .build();
-    }
+    aclEntry.setPermissions(Arrays.asList(permissions));
 
     aclRepository.save(aclEntry);
   }

--- a/auth-service/src/main/java/com/kioke/auth/service/JournalService.java
+++ b/auth-service/src/main/java/com/kioke/auth/service/JournalService.java
@@ -1,0 +1,21 @@
+package com.kioke.auth.service;
+
+import com.kioke.auth.model.Journal;
+import com.kioke.auth.repository.JournalRepository;
+import java.util.NoSuchElementException;
+import org.hibernate.validator.internal.util.stereotypes.Lazy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class JournalService {
+  @Autowired @Lazy JournalRepository journalRepository;
+
+  public Journal getJournalById(String jid) {
+    try {
+      return journalRepository.findById(jid).get();
+    } catch (NoSuchElementException e) {
+      return journalRepository.save(Journal.builder().jid(jid).build());
+    }
+  }
+}

--- a/auth-service/src/main/java/com/kioke/auth/service/JournalService.java
+++ b/auth-service/src/main/java/com/kioke/auth/service/JournalService.java
@@ -11,7 +11,11 @@ import org.springframework.stereotype.Service;
 public class JournalService {
   @Autowired @Lazy JournalRepository journalRepository;
 
-  public Journal getJournalById(String jid) {
+  public Journal getJournal(String jid) throws NoSuchElementException {
+    return journalRepository.findById(jid).get();
+  }
+
+  public Journal getOrCreateJournal(String jid) {
     try {
       return journalRepository.findById(jid).get();
     } catch (NoSuchElementException e) {

--- a/auth-service/src/main/java/com/kioke/auth/service/UserService.java
+++ b/auth-service/src/main/java/com/kioke/auth/service/UserService.java
@@ -11,7 +11,11 @@ import org.springframework.stereotype.Service;
 public class UserService {
   @Autowired @Lazy UserRepository userRepository;
 
-  public User getUserById(String uid) {
+  public User getUser(String uid) throws NoSuchElementException {
+    return userRepository.findById(uid).get();
+  }
+
+  public User getOrCreateUser(String uid) {
     try {
       return userRepository.findById(uid).get();
     } catch (NoSuchElementException e) {

--- a/auth-service/src/main/java/com/kioke/auth/service/UserService.java
+++ b/auth-service/src/main/java/com/kioke/auth/service/UserService.java
@@ -1,0 +1,21 @@
+package com.kioke.auth.service;
+
+import com.kioke.auth.model.User;
+import com.kioke.auth.repository.UserRepository;
+import java.util.NoSuchElementException;
+import org.hibernate.validator.internal.util.stereotypes.Lazy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+  @Autowired @Lazy UserRepository userRepository;
+
+  public User getUserById(String uid) {
+    try {
+      return userRepository.findById(uid).get();
+    } catch (NoSuchElementException e) {
+      return userRepository.save(User.builder().uid(uid).build());
+    }
+  }
+}

--- a/journal-service/src/main/java/com/kioke/journal/constant/KiokeServices.java
+++ b/journal-service/src/main/java/com/kioke/journal/constant/KiokeServices.java
@@ -1,0 +1,17 @@
+package com.kioke.journal.constant;
+
+public enum KiokeServices {
+  AUTH_SERVICE("Kioke Auth Service"),
+  USER_SERVICE("Kioke User Service"),
+  JOURNAL_SERVICE("Kioke Journal Service");
+
+  String serviceId;
+
+  private KiokeServices(String serviceId) {
+    this.serviceId = serviceId;
+  }
+
+  public String getServiceId() {
+    return serviceId;
+  }
+}

--- a/journal-service/src/main/java/com/kioke/journal/dto/external/auth/AuthServiceCreateJournalRequestBodyDto.java
+++ b/journal-service/src/main/java/com/kioke/journal/dto/external/auth/AuthServiceCreateJournalRequestBodyDto.java
@@ -1,0 +1,11 @@
+package com.kioke.journal.dto.external.auth;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AuthServiceCreateJournalRequestBodyDto {
+  private String jid;
+  private String uid;
+}

--- a/journal-service/src/main/java/com/kioke/journal/exception/GlobalExceptionHandler.java
+++ b/journal-service/src/main/java/com/kioke/journal/exception/GlobalExceptionHandler.java
@@ -28,6 +28,7 @@ public class GlobalExceptionHandler {
     MethodArgumentNotValidException.class,
     JournalNotFoundException.class,
     DateTimeParseException.class,
+    ServiceNotFoundException.class,
     Exception.class
   })
   public ResponseEntity<ResponseDto<EmptyResponseDataDto>> handleException(

--- a/journal-service/src/main/java/com/kioke/journal/exception/ServiceFailedException.java
+++ b/journal-service/src/main/java/com/kioke/journal/exception/ServiceFailedException.java
@@ -1,16 +1,18 @@
 package com.kioke.journal.exception;
 
+import com.kioke.journal.constant.KiokeServices;
+
 public class ServiceFailedException extends Exception {
-  private String serviceId;
+  private KiokeServices service;
   private String details;
 
-  public ServiceFailedException(String serviceId, String details) {
-    this.serviceId = serviceId;
+  public ServiceFailedException(KiokeServices service, String details) {
+    this.service = service;
     this.details = details;
   }
 
   @Override
   public String toString() {
-    return "Service of ID " + serviceId + " has failed due to exception " + details;
+    return "Service [" + service.getServiceId() + "] has failed due to exception " + details;
   }
 }

--- a/journal-service/src/main/java/com/kioke/journal/exception/ServiceFailedException.java
+++ b/journal-service/src/main/java/com/kioke/journal/exception/ServiceFailedException.java
@@ -1,0 +1,16 @@
+package com.kioke.journal.exception;
+
+public class ServiceFailedException extends Exception {
+  private String serviceId;
+  private String details;
+
+  public ServiceFailedException(String serviceId, String details) {
+    this.serviceId = serviceId;
+    this.details = details;
+  }
+
+  @Override
+  public String toString() {
+    return "Service of ID " + serviceId + " has failed due to exception " + details;
+  }
+}

--- a/journal-service/src/main/java/com/kioke/journal/exception/ServiceNotFoundException.java
+++ b/journal-service/src/main/java/com/kioke/journal/exception/ServiceNotFoundException.java
@@ -1,0 +1,14 @@
+package com.kioke.journal.exception;
+
+public class ServiceNotFoundException extends Exception {
+  private String serviceId;
+
+  public ServiceNotFoundException(String serviceId) {
+    this.serviceId = serviceId;
+  }
+
+  @Override
+  public String toString() {
+    return "Service of ID " + serviceId + " could not be found.";
+  }
+}

--- a/journal-service/src/main/java/com/kioke/journal/exception/ServiceNotFoundException.java
+++ b/journal-service/src/main/java/com/kioke/journal/exception/ServiceNotFoundException.java
@@ -1,14 +1,16 @@
 package com.kioke.journal.exception;
 
-public class ServiceNotFoundException extends Exception {
-  private String serviceId;
+import com.kioke.journal.constant.KiokeServices;
 
-  public ServiceNotFoundException(String serviceId) {
-    this.serviceId = serviceId;
+public class ServiceNotFoundException extends Exception {
+  private KiokeServices service;
+
+  public ServiceNotFoundException(KiokeServices service) {
+    this.service = service;
   }
 
   @Override
   public String toString() {
-    return "Service of ID " + serviceId + " could not be found.";
+    return "Service [" + service.getServiceId() + "] could not be found.";
   }
 }

--- a/journal-service/src/main/java/com/kioke/journal/service/DiscoveryClientService.java
+++ b/journal-service/src/main/java/com/kioke/journal/service/DiscoveryClientService.java
@@ -35,7 +35,7 @@ public class DiscoveryClientService {
   private String getServiceUri(KiokeServices service) throws ServiceNotFoundException {
     List<ServiceInstance> instances = discoveryClient.getInstances(service.getServiceId());
     if (instances.size() == 0) {
-      throw new ServiceNotFoundException(service.getServiceId());
+      throw new ServiceNotFoundException(service);
     }
 
     int index = getRandomIndex(instances.size());

--- a/journal-service/src/main/java/com/kioke/journal/service/DiscoveryClientService.java
+++ b/journal-service/src/main/java/com/kioke/journal/service/DiscoveryClientService.java
@@ -1,0 +1,51 @@
+package com.kioke.journal.service;
+
+import com.kioke.journal.constant.KiokeServices;
+import com.kioke.journal.exception.ServiceFailedException;
+import com.kioke.journal.exception.ServiceNotFoundException;
+import java.util.List;
+import java.util.Random;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.annotation.Lazy;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+@Service
+public class DiscoveryClientService {
+  @Autowired @Lazy DiscoveryClient discoveryClient;
+
+  @Retryable(
+      retryFor = ServiceFailedException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100))
+  public <T> RestClient getRestClient(KiokeServices service, String path)
+      throws ServiceFailedException, ServiceNotFoundException {
+    String requestUri = getServiceUri(service) + path;
+    return RestClient.create(requestUri);
+  }
+
+  @Retryable(
+      retryFor = ServiceNotFoundException.class,
+      maxAttempts = 3,
+      backoff = @Backoff(delay = 100))
+  private String getServiceUri(KiokeServices service) throws ServiceNotFoundException {
+    List<ServiceInstance> instances = discoveryClient.getInstances(service.getServiceId());
+    if (instances.size() == 0) {
+      throw new ServiceNotFoundException(service.getServiceId());
+    }
+
+    int index = getRandomIndex(instances.size());
+    ServiceInstance instance = instances.get(index);
+
+    return instance.getUri().toString();
+  }
+
+  private static int getRandomIndex(int size) {
+    Random random = new Random();
+    return random.nextInt(size);
+  }
+}

--- a/journal-service/src/main/java/com/kioke/journal/service/JournalService.java
+++ b/journal-service/src/main/java/com/kioke/journal/service/JournalService.java
@@ -15,6 +15,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientResponseException;
 
 @Service
 public class JournalService {
@@ -42,9 +43,13 @@ public class JournalService {
                   .build())
           .retrieve();
 
-    } catch (Exception e) {
+    } catch (ServiceNotFoundException e) {
       journalRepository.deleteById(savedJournal.getId());
-      throw new ServiceFailedException(KiokeServices.AUTH_SERVICE.getServiceId(), e.toString());
+      throw e;
+
+    } catch (RestClientResponseException e) {
+      journalRepository.deleteById(savedJournal.getId());
+      throw new ServiceFailedException(KiokeServices.AUTH_SERVICE, e.getMessage());
     }
 
     messageProducerService.createJournal(


### PR DESCRIPTION
## Description
- Add logic for creating journal permissions in auth service
- The journal service queries the Eureka Discovery server to get an instance of the auth service.
- After creating a journal, the journal service queries the auth service to add a new AclEntry permissions row.

## Pull Request Type
- [x] Add a new feature.
- [ ] Fix an existing bug.
- [ ] Refactor code.
- [ ] CI related changes.
- [ ] Documentation related changes.
- [ ] Other

## Related Issues
- Closes #37 