### PR TITLE
perf: reduce docker image sizes for backend services

### DIFF
--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1
 FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /app
@@ -11,8 +10,20 @@ COPY src src
 
 RUN mvn package -DskipTests
 
-# Stage 2
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17 as jre-builder
+
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules ALL-MODULE-PATH \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /javaruntime
+
+FROM debian:buster-slim
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-builder /javaruntime $JAVA_HOME
 
 RUN addgroup --system kioke && adduser --system --group kioke
 

--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1
 FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /app
@@ -11,8 +10,20 @@ COPY src src
 
 RUN mvn package -DskipTests
 
-# Stage 2
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17 as jre-builder
+
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules ALL-MODULE-PATH \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /javaruntime
+
+FROM debian:buster-slim
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-builder /javaruntime $JAVA_HOME
 
 RUN addgroup --system kioke && adduser --system --group kioke
 

--- a/journal-service/Dockerfile
+++ b/journal-service/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1
 FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /app
@@ -11,8 +10,20 @@ COPY src src
 
 RUN mvn package -DskipTests
 
-# Stage 2
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17 as jre-builder
+
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules ALL-MODULE-PATH \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /javaruntime
+
+FROM debian:buster-slim
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-builder /javaruntime $JAVA_HOME
 
 RUN addgroup --system kioke && adduser --system --group kioke
 

--- a/service-discovery/Dockerfile
+++ b/service-discovery/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1
 FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /app
@@ -11,8 +10,20 @@ COPY src src
 
 RUN mvn package -DskipTests
 
-# Stage 2
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17 as jre-builder
+
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules ALL-MODULE-PATH \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /javaruntime
+
+FROM debian:buster-slim
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-builder /javaruntime $JAVA_HOME
 
 RUN addgroup --system kioke && adduser --system --group kioke
 

--- a/user-service/Dockerfile
+++ b/user-service/Dockerfile
@@ -1,4 +1,3 @@
-# Stage 1
 FROM maven:3.9-eclipse-temurin-17 AS builder
 
 WORKDIR /app
@@ -11,8 +10,20 @@ COPY src src
 
 RUN mvn package -DskipTests
 
-# Stage 2
-FROM eclipse-temurin:17
+FROM eclipse-temurin:17 as jre-builder
+
+RUN $JAVA_HOME/bin/jlink \
+    --add-modules ALL-MODULE-PATH \
+    --strip-debug \
+    --no-man-pages \
+    --no-header-files \
+    --compress=2 \
+    --output /javaruntime
+
+FROM debian:buster-slim
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-builder /javaruntime $JAVA_HOME
 
 RUN addgroup --system kioke && adduser --system --group kioke
 


### PR DESCRIPTION
## Description
- The current version of kioke's backend services uses eclipse-temurin:17 as its base image.
- This updated version only used eclipse-temurin as the builder image where we only take the Java runtime from this image. Here, debian:buster-slim is used as the main image.

## Pull Request Type
- [ ] Add a new feature.
- [ ] Fix an existing bug.
- [x] Refactor code.
- [ ] CI related changes.
- [ ] Documentation related changes.
- [ ] Other

## Related Issues
- Closes #45