### PR TITLE
fix: modify shelf and journal data relationship

### DIFF
--- a/journal-service/src/main/java/com/kioke/journal/dto/response/shelf/GetShelvesResponseBodyDto.java
+++ b/journal-service/src/main/java/com/kioke/journal/dto/response/shelf/GetShelvesResponseBodyDto.java
@@ -36,7 +36,10 @@ public class GetShelvesResponseBodyDto {
       return ShelfDto.builder()
           .id(shelf.getId())
           .name(shelf.getName())
-          .journals(shelf.getJournals().stream().map(journal -> JournalDto.from(journal)).toList())
+          .journals(
+              shelf.getShelfSlots().stream()
+                  .map(shelfSlot -> JournalDto.from(shelfSlot.getJournal()))
+                  .toList())
           .isArchive(shelf.isArchive())
           .build();
     }

--- a/journal-service/src/main/java/com/kioke/journal/model/Journal.java
+++ b/journal-service/src/main/java/com/kioke/journal/model/Journal.java
@@ -1,13 +1,9 @@
 package com.kioke.journal.model;
 
-import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
@@ -31,9 +27,8 @@ public class Journal {
   @OneToMany(mappedBy = "journal", orphanRemoval = true)
   private List<JournalPermission> users;
 
-  @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-  @JoinColumn(name = "SHELF_ID")
-  private Shelf shelf;
+  @OneToMany(mappedBy = "journal", orphanRemoval = true)
+  private List<ShelfSlot> shelves;
 
   @NotNull private String title;
 

--- a/journal-service/src/main/java/com/kioke/journal/model/ShelfSlot.java
+++ b/journal-service/src/main/java/com/kioke/journal/model/ShelfSlot.java
@@ -8,34 +8,32 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
-import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "SHELF_TABLE")
+@Table(name = "JOURNAL_SHELF_TABLE")
 @Data
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 @Builder
-public class Shelf {
+public class ShelfSlot {
   @Id
   @GeneratedValue(strategy = GenerationType.UUID)
   private String id;
 
   @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-  @JoinColumn(name = "USER_ID", nullable = false)
-  private User owner;
+  @JoinColumn(name = "USER_ID")
+  private User user;
 
-  @OneToMany(mappedBy = "shelf", orphanRemoval = true)
-  private List<ShelfSlot> shelfSlots;
+  @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+  @JoinColumn(name = "SHELF_ID")
+  private Shelf shelf;
 
-  private String name;
-
-  @NotNull private boolean isArchive;
+  @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+  @JoinColumn(name = "JOURNAL_ID")
+  private Journal journal;
 }

--- a/journal-service/src/main/java/com/kioke/journal/model/User.java
+++ b/journal-service/src/main/java/com/kioke/journal/model/User.java
@@ -23,5 +23,8 @@ public class User {
   private List<Shelf> shelves;
 
   @OneToMany(mappedBy = "user")
+  private List<ShelfSlot> shelfSlots;
+
+  @OneToMany(mappedBy = "user")
   private List<JournalPermission> journals;
 }

--- a/journal-service/src/main/java/com/kioke/journal/repository/ShelfSlotRepository.java
+++ b/journal-service/src/main/java/com/kioke/journal/repository/ShelfSlotRepository.java
@@ -1,0 +1,11 @@
+package com.kioke.journal.repository;
+
+import com.kioke.journal.model.Journal;
+import com.kioke.journal.model.ShelfSlot;
+import com.kioke.journal.model.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ShelfSlotRepository extends JpaRepository<ShelfSlot, String> {
+  public Optional<ShelfSlot> findByUserAndJournal(User user, Journal journal);
+}

--- a/journal-service/src/main/java/com/kioke/journal/service/JournalService.java
+++ b/journal-service/src/main/java/com/kioke/journal/service/JournalService.java
@@ -2,11 +2,10 @@ package com.kioke.journal.service;
 
 import com.kioke.journal.exception.journal.JournalNotFoundException;
 import com.kioke.journal.model.Journal;
-import com.kioke.journal.model.Shelf;
 import com.kioke.journal.model.User;
 import com.kioke.journal.repository.JournalRepository;
-import com.kioke.journal.repository.ShelfRepository;
 import java.util.ArrayList;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -14,18 +13,17 @@ import org.springframework.stereotype.Service;
 @Service
 public class JournalService {
   @Autowired @Lazy JournalRepository journalRepository;
-  @Autowired @Lazy ShelfRepository shelfRepository;
 
   public Journal getJournalById(String jid) throws JournalNotFoundException {
     return journalRepository.findById(jid).orElseThrow(() -> new JournalNotFoundException());
   }
 
-  public Journal createJournal(User user, Shelf shelf, String title) {
+  public Journal createJournal(User user, String title) {
     Journal journal =
         Journal.builder()
             .title(title)
             .users(new ArrayList<>())
-            .shelf(shelf)
+            .shelves(new ArrayList<>())
             .isDeleted(false)
             .build();
 
@@ -33,19 +31,14 @@ public class JournalService {
     return journal;
   }
 
-  public void deleteJournal(User user, Journal journal) {
+  public Optional<Journal> deleteJournal(User user, Journal journal) {
     if (journal.isDeleted()) {
       journalRepository.delete(journal);
-      return;
+      return Optional.empty();
     }
 
-    Shelf archive =
-        shelfRepository
-            .findByOwnerAndIsArchiveTrue(user)
-            .orElseThrow(() -> new IllegalStateException("User does not have archive shelf."));
-
     journal.setDeleted(true);
-    journal.setShelf(archive);
-    journalRepository.save(journal);
+    journal = journalRepository.save(journal);
+    return Optional.of(journal);
   }
 }

--- a/journal-service/src/main/java/com/kioke/journal/service/ShelfService.java
+++ b/journal-service/src/main/java/com/kioke/journal/service/ShelfService.java
@@ -1,10 +1,14 @@
 package com.kioke.journal.service;
 
 import com.kioke.journal.exception.shelf.ShelfNotFoundException;
+import com.kioke.journal.model.Journal;
 import com.kioke.journal.model.Shelf;
+import com.kioke.journal.model.ShelfSlot;
 import com.kioke.journal.model.User;
 import com.kioke.journal.repository.ShelfRepository;
+import com.kioke.journal.repository.ShelfSlotRepository;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
@@ -12,6 +16,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class ShelfService {
   @Autowired @Lazy private ShelfRepository shelfRepository;
+  @Autowired @Lazy private ShelfSlotRepository shelfSlotRepository;
 
   public Shelf createShelf(User user, String name) {
     Shelf shelf = Shelf.builder().name(name).owner(user).isArchive(false).build();
@@ -31,5 +36,30 @@ public class ShelfService {
 
   public List<Shelf> getShelves(User user) {
     return user.getShelves();
+  }
+
+  public Shelf getArchive(User user) {
+    Shelf archive =
+        shelfRepository
+            .findByOwnerAndIsArchiveTrue(user)
+            .orElseThrow(() -> new IllegalStateException("User does not have archive shelf."));
+
+    return archive;
+  }
+
+  public void putJournalInShelf(Journal journal, Shelf shelf) {
+    User user = shelf.getOwner();
+    Optional<ShelfSlot> existingShelfSlot =
+        shelfSlotRepository.findByUserAndJournal(user, journal);
+
+    ShelfSlot shelfSlot;
+    if (existingShelfSlot.isPresent()) {
+      shelfSlot = existingShelfSlot.get();
+      shelfSlot.setShelf(shelf);
+    } else {
+      shelfSlot = ShelfSlot.builder().user(user).shelf(shelf).journal(journal).build();
+    }
+
+    shelfSlotRepository.save(shelfSlot);
   }
 }


### PR DESCRIPTION
## Description
- The previous data model between the shelf and journal limited each journal to be inside only one shelf.
- When journals will be shared, this will become an issue.
- A join table is introduced to apply the many-to-many relationship between journals and shelves.
- The user ID is stored within the join table for efficient queries.

## Pull Request Type
- [x] Add a new feature.
- [ ] Fix an existing bug.
- [ ] Refactor code.
- [ ] CI related changes.
- [ ] Documentation related changes.
- [ ] Other

## Related Issues
- Closes #91 